### PR TITLE
feat: Refactor summary and insights generation functionality

### DIFF
--- a/client/src/app/journal.tsx
+++ b/client/src/app/journal.tsx
@@ -14,6 +14,8 @@ const JournalView = () => {
     journalTitle,
     isEditing,
     isEditingTitle,
+    isGeneratingInsights,
+    isGeneratingSummary,
     snippets,
     journal,
     setActiveTab,
@@ -23,7 +25,8 @@ const JournalView = () => {
     handleToggleEdit,
     handleTitleEditEnd,
     handleBackToDashboard,
-    handleSummarize,
+    handleGenerateInsights,
+    handleGenerateJournalFromSnippets,
   } = useJournalState(journalId);
 
   return (
@@ -45,10 +48,12 @@ const JournalView = () => {
             journalContent={journalContent}
             isEditing={isEditing}
             snippets={snippets}
-            journalId={journal?.id}
             onContentChange={setJournalContent}
             onToggleEdit={handleToggleEdit}
-            onSummarize={handleSummarize}
+            generateJournalFromSnippets={handleGenerateJournalFromSnippets}
+            generateAIInsights={handleGenerateInsights}
+            isGenerating={isGeneratingSummary}
+            isGeneratingInsights={isGeneratingInsights}
           />
         ) : (
           <InsightsTab snippets={snippets} journal={journal} />

--- a/client/src/components/journal/EditTab.tsx
+++ b/client/src/components/journal/EditTab.tsx
@@ -4,18 +4,15 @@ import { JournalEditor } from './JournalEditor';
 import { QuickStats } from './QuickStats';
 import { SnippetsOverview } from './SnippetsOverview';
 import type { Snippet } from '@/model/snippet';
-import { useGetSummary } from '@/api/journal';
 
 interface EditTabProps {
   journalContent: string;
   isEditing: boolean;
   snippets: Array<Snippet>;
-  journalId?: string;
   onContentChange: (content: string) => void;
   onToggleEdit: () => void;
-  onSummarize?: (summary: string) => void;
   generateJournalFromSnippets?: () => void;
-  generateAIInsights?: (content: string, snippets: Array<Snippet>) => void;
+  generateAIInsights?: () => void;
   isGenerating?: boolean;
   isGeneratingInsights?: boolean;
 }
@@ -24,48 +21,26 @@ export const EditTab = ({
   journalContent,
   isEditing,
   snippets,
-  journalId,
   onContentChange,
   onToggleEdit,
-  onSummarize,
   generateJournalFromSnippets,
   generateAIInsights,
   isGenerating = false,
   isGeneratingInsights = false,
 }: EditTabProps) => {
-  const { isLoading: isSummaryLoading, refetch: fetchSummary } = useGetSummary(
-    journalId || '',
-    false,
-  );
-
-  const handleSummarize = async () => {
-    if (journalId && onSummarize) {
-      try {
-        const result = await fetchSummary();
-        if (result.data) {
-          onSummarize(result.data);
-        }
-      } catch (error) {
-        console.error('Failed to fetch summary:', error);
-      }
-    }
-  };
-
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
+    <div className="grid grid-cols-1 lg:grid-cols-4 gap-8 relative">
       <div className="lg:col-span-3">
         <JournalEditor
           content={journalContent}
           isEditing={isEditing}
-          isLoading={isGenerating || isGeneratingInsights || isSummaryLoading}
+          isLoading={isGenerating || isGeneratingInsights}
           loadingMessage={
             isGenerating
               ? 'ZenAI is generating your journal...'
               : isGeneratingInsights
                 ? 'ZenAI is analyzing your insights...'
-                : isSummaryLoading
-                  ? 'ZenAI is summarizing your content...'
-                  : 'ZenAI is thinking...'
+                : 'ZenAI is thinking...'
           }
           onContentChange={onContentChange}
           onToggleEdit={onToggleEdit}
@@ -85,7 +60,11 @@ export const EditTab = ({
               <motion.button
                 onClick={generateJournalFromSnippets}
                 disabled={isGenerating || snippets.length === 0}
-                className="w-full bg-gradient-to-r from-purple-500 to-blue-500 hover:from-purple-600 hover:to-blue-600 disabled:from-gray-300 disabled:to-gray-300 disabled:cursor-not-allowed text-white px-4 py-3 rounded-lg flex items-center justify-center space-x-2 transition-all shadow-md hover:shadow-lg disabled:shadow-none font-medium"
+                className={`w-full px-4 py-3 rounded-lg flex items-center justify-center space-x-2 transition-all shadow-md hover:shadow-lg disabled:shadow-none font-medium ${
+                  isGenerating
+                    ? 'bg-gradient-to-r from-purple-400 to-blue-400 text-white animate-pulse'
+                    : 'bg-gradient-to-r from-purple-500 to-blue-500 hover:from-purple-600 hover:to-blue-600 disabled:from-gray-300 disabled:to-gray-300 disabled:cursor-not-allowed text-white'
+                }`}
                 whileHover={{
                   scale: isGenerating || snippets.length === 0 ? 1 : 1.02,
                 }}
@@ -94,7 +73,16 @@ export const EditTab = ({
                 }}
               >
                 {isGenerating ? (
-                  <RefreshCw className="w-4 h-4 animate-spin" />
+                  <motion.div
+                    animate={{ rotate: 360 }}
+                    transition={{
+                      duration: 1,
+                      repeat: Infinity,
+                      ease: 'linear',
+                    }}
+                  >
+                    <RefreshCw className="w-4 h-4" />
+                  </motion.div>
                 ) : (
                   <Sparkles className="w-4 h-4" />
                 )}
@@ -106,48 +94,38 @@ export const EditTab = ({
 
             {generateAIInsights && (
               <motion.button
-                onClick={() => generateAIInsights(journalContent, snippets)}
-                disabled={isGeneratingInsights || !journalContent.trim()}
-                className="w-full bg-gradient-to-r from-teal-500 to-green-500 hover:from-teal-600 hover:to-green-600 disabled:from-gray-300 disabled:to-gray-300 disabled:cursor-not-allowed text-white px-4 py-3 rounded-lg flex items-center justify-center space-x-2 transition-all shadow-md hover:shadow-lg disabled:shadow-none font-medium"
+                onClick={() => generateAIInsights()}
+                disabled={isGeneratingInsights || snippets.length === 0}
+                className={`w-full px-4 py-3 rounded-lg flex items-center justify-center space-x-2 transition-all shadow-md hover:shadow-lg disabled:shadow-none font-medium ${
+                  isGeneratingInsights
+                    ? 'bg-gradient-to-r from-teal-400 to-green-400 text-white animate-pulse'
+                    : 'bg-gradient-to-r from-teal-500 to-green-500 hover:from-teal-600 hover:to-green-600 disabled:from-gray-300 disabled:to-gray-300 disabled:cursor-not-allowed text-white'
+                }`}
                 whileHover={{
                   scale:
-                    isGeneratingInsights || !journalContent.trim() ? 1 : 1.02,
+                    isGeneratingInsights || snippets.length === 0 ? 1 : 1.02,
                 }}
                 whileTap={{
                   scale:
-                    isGeneratingInsights || !journalContent.trim() ? 1 : 0.98,
+                    isGeneratingInsights || snippets.length === 0 ? 1 : 0.98,
                 }}
               >
                 {isGeneratingInsights ? (
-                  <RefreshCw className="w-4 h-4 animate-spin" />
+                  <motion.div
+                    animate={{ rotate: 360 }}
+                    transition={{
+                      duration: 1,
+                      repeat: Infinity,
+                      ease: 'linear',
+                    }}
+                  >
+                    <RefreshCw className="w-4 h-4" />
+                  </motion.div>
                 ) : (
                   <Zap className="w-4 h-4" />
                 )}
                 <span>
                   {isGeneratingInsights ? 'Analyzing...' : 'Generate Insights'}
-                </span>
-              </motion.button>
-            )}
-
-            {journalId && snippets.length > 2 && (
-              <motion.button
-                onClick={handleSummarize}
-                disabled={isSummaryLoading || !journalContent.trim()}
-                className="w-full bg-gradient-to-r from-orange-500 to-red-500 hover:from-orange-600 hover:to-red-600 disabled:from-gray-300 disabled:to-gray-300 disabled:cursor-not-allowed text-white px-4 py-3 rounded-lg flex items-center justify-center space-x-2 transition-all shadow-md hover:shadow-lg disabled:shadow-none font-medium"
-                whileHover={{
-                  scale: isSummaryLoading || !journalContent.trim() ? 1 : 1.02,
-                }}
-                whileTap={{
-                  scale: isSummaryLoading || !journalContent.trim() ? 1 : 0.98,
-                }}
-              >
-                {isSummaryLoading ? (
-                  <RefreshCw className="w-4 h-4 animate-spin" />
-                ) : (
-                  <Sparkles className="w-4 h-4" />
-                )}
-                <span>
-                  {isSummaryLoading ? 'Summarizing...' : 'Summarize Journal'}
                 </span>
               </motion.button>
             )}

--- a/client/src/components/journal/JournalEditor.tsx
+++ b/client/src/components/journal/JournalEditor.tsx
@@ -22,16 +22,16 @@ export const JournalEditor = ({
     onContentChange(e.target.value);
   };
 
+  const handleContentClick = () => {
+    if (!isLoading) {
+      onToggleEdit();
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       onToggleEdit(); // save and exit edit mode
-    }
-  };
-
-  const handleContentClick = () => {
-    if (!isEditing) {
-      onToggleEdit(); // start editing when clicking on the content
     }
   };
 
@@ -48,15 +48,23 @@ export const JournalEditor = ({
             {isEditing && (
               <button
                 onClick={onToggleEdit}
-                className="px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-100 text-gray-600 hover:bg-gray-200"
+                disabled={isLoading}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  isLoading
+                    ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
               >
                 Cancel
               </button>
             )}
             <button
               onClick={onToggleEdit}
+              disabled={isLoading}
               className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                isEditing
+                isLoading
+                  ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                  : isEditing
                   ? 'bg-teal-500 text-white hover:bg-teal-600'
                   : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
               }`}
@@ -99,7 +107,6 @@ export const JournalEditor = ({
                   >
                     <div className="flex items-center space-x-2">
                       <Brain className="w-5 h-5 text-purple-600 animate-pulse" />
-                      <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-teal-600"></div>
                     </div>
                     <p className="text-sm font-medium text-gray-700">
                       {loadingMessage}
@@ -129,13 +136,17 @@ export const JournalEditor = ({
         ) : (
           <div className="prose prose-lg max-w-none relative">
             <div
-              className="whitespace-pre-wrap text-gray-700 leading-relaxed cursor-text hover:bg-gray-50 transition-colors rounded-lg p-2 -m-2"
+              className={`whitespace-pre-wrap text-gray-700 leading-relaxed transition-colors rounded-lg p-2 -m-2 ${
+                isLoading
+                  ? 'cursor-not-allowed opacity-60'
+                  : 'cursor-text hover:bg-gray-50'
+              }`}
               style={{ minHeight: '400px' }}
               onClick={handleContentClick}
               role="button"
               tabIndex={0}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
+                if ((e.key === 'Enter' || e.key === ' ') && !isLoading) {
                   handleContentClick();
                 }
               }}
@@ -164,7 +175,6 @@ export const JournalEditor = ({
                   >
                     <div className="flex items-center space-x-2">
                       <Brain className="w-5 h-5 text-purple-600 animate-pulse" />
-                      <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-teal-600"></div>
                     </div>
                     <p className="text-sm font-medium text-gray-700">
                       {loadingMessage}

--- a/client/src/components/journal/JournalEditor.tsx
+++ b/client/src/components/journal/JournalEditor.tsx
@@ -65,8 +65,8 @@ export const JournalEditor = ({
                 isLoading
                   ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
                   : isEditing
-                  ? 'bg-teal-500 text-white hover:bg-teal-600'
-                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                    ? 'bg-teal-500 text-white hover:bg-teal-600'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
               }`}
             >
               {isEditing ? 'Save' : 'Edit'}

--- a/genai/app/routers/summary.py
+++ b/genai/app/routers/summary.py
@@ -1,12 +1,20 @@
 from fastapi import APIRouter
-from app.models.schemas import SummaryRequest, SummaryResponse
+from app.models.schemas import SummaryRequest
 from app.services.summary_service import SummaryService
+from app.services.insights_service import InsightsService
 
 router = APIRouter(prefix="/api/genai")
 summary_service = SummaryService()
+insights_service = InsightsService()
 
 
-@router.post("/summary", response_model=SummaryResponse)
-async def summarize(request: SummaryRequest):
-    """Summarize journal snippets and provide insights"""
+@router.post("/summary", response_model=dict)
+async def get_summary(request: SummaryRequest):
+    """Get only the summary from journal snippets"""
     return summary_service.process_summary(request)
+
+
+@router.post("/insights", response_model=dict)
+async def get_insights(request: SummaryRequest):
+    """Get only the insights and analysis from journal snippets"""
+    return insights_service.process_insights(request)

--- a/genai/app/services/insights_service.py
+++ b/genai/app/services/insights_service.py
@@ -1,0 +1,98 @@
+import traceback
+from fastapi import HTTPException
+from langchain.chains import LLMChain
+from langchain.prompts import PromptTemplate
+from app.models.schemas import SummaryRequest
+from app.services.llm_service import OpenWebUILLM
+
+
+class InsightsService:
+    """Service for handling insights generation operations"""
+    
+    def __init__(self):
+        # Initialize the LLM
+        self.llm = OpenWebUILLM()
+        
+        # Create the prompt template for insights
+        self.insights_prompt = PromptTemplate(
+            input_variables=["input_text"],
+            template="""
+You are a thoughtful journal assistant.
+
+Given the following snippets a user has recorded throughout their day:
+
+{input_text}
+
+Please provide insights and analysis with two sections:
+
+1. Write an Analysis section **addressed directly to the user**, using "you" and "your" (instead of "the user"). Provide insights about the emotions you might have felt based on the snippets, and suggest possible recommendations for how you could feel happier or improve your wellbeing.
+
+2. Provide specific Insights in the following four categories:
+   - Mood Pattern: Analyze the emotional patterns throughout the day
+   - Suggestion: Provide one actionable recommendation for improvement
+   - Achievement: Identify one positive accomplishment or strength shown
+   - Wellness Tip: Give one specific wellness or self-care recommendation
+
+Format your response exactly as:
+
+Analysis:
+<analysis and recommendations here>
+
+Insights:
+Mood Pattern: <mood pattern analysis>
+Suggestion: <actionable suggestion>
+Achievement: <positive accomplishment>
+Wellness Tip: <wellness recommendation>
+"""
+        )
+        self.insights_chain = LLMChain(llm=self.llm, prompt=self.insights_prompt)
+    
+    def process_insights(self, request: SummaryRequest) -> dict:
+        """Process insights request and return structured response"""
+        if not request.snippetContents:
+            raise HTTPException(status_code=400, detail="snippetContents list cannot be empty.")
+
+        try:
+            combined = "\n\n".join(request.snippetContents)
+            output = self.insights_chain.run(combined)
+
+            # Initialize default values
+            analysis_text = ""
+            insights_dict = {
+                "moodPattern": "",
+                "suggestion": "",
+                "achievement": "",
+                "wellnessTip": ""
+            }
+
+            # Split the output into sections
+            sections = output.split("Insights:")
+            if len(sections) >= 2:
+                # Extract analysis
+                analysis_text = sections[0].replace("Analysis:", "").strip()
+                
+                # Parse insights if available
+                insights_text = sections[1].strip()
+                
+                # Parse each insight category
+                for line in insights_text.split('\n'):
+                    line = line.strip()
+                    if line.startswith("Mood Pattern:"):
+                        insights_dict["moodPattern"] = line.replace("Mood Pattern:", "").strip()
+                    elif line.startswith("Suggestion:"):
+                        insights_dict["suggestion"] = line.replace("Suggestion:", "").strip()
+                    elif line.startswith("Achievement:"):
+                        insights_dict["achievement"] = line.replace("Achievement:", "").strip()
+                    elif line.startswith("Wellness Tip:"):
+                        insights_dict["wellnessTip"] = line.replace("Wellness Tip:", "").strip()
+            else:
+                # Fallback: no proper sections found
+                analysis_text = output.strip()
+
+            return {
+                "analysis": analysis_text,
+                "insights": insights_dict
+            }
+        except Exception as e:
+            traceback.print_exc()
+            raise HTTPException(status_code=500, detail=f"Insights generation failed: {str(e)}")

--- a/genai/app/services/summary_service.py
+++ b/genai/app/services/summary_service.py
@@ -2,7 +2,7 @@ import traceback
 from fastapi import HTTPException
 from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
-from app.models.schemas import SummaryRequest, SummaryResponse, InsightsResponse
+from app.models.schemas import SummaryRequest
 from app.services.llm_service import OpenWebUILLM
 
 
@@ -13,7 +13,7 @@ class SummaryService:
         # Initialize the LLM
         self.llm = OpenWebUILLM()
         
-        # Create the prompt template
+        # Create the prompt template for summary only
         self.summary_prompt = PromptTemplate(
             input_variables=["input_text"],
             template="""
@@ -23,36 +23,17 @@ Given the following snippets a user has recorded throughout their day:
 
 {input_text}
 
-Please provide a comprehensive analysis with three sections:
-
-1. Write a concise and reflective Journal Summary as if the user wrote it themselves, using first-person language ("I", "my"). Use **only** the information in the snippets—do not add any thoughts, feelings, or actions not described.
-
-2. Write an Analysis section **addressed directly to the user**, using "you" and "your" (instead of "the user"). Provide insights about the emotions you might have felt based on the snippets, and suggest possible recommendations for how you could feel happier or improve your wellbeing.
-
-3. Provide specific Insights in the following four categories:
-   - Mood Pattern: Analyze the emotional patterns throughout the day
-   - Suggestion: Provide one actionable recommendation for improvement
-   - Achievement: Identify one positive accomplishment or strength shown
-   - Wellness Tip: Give one specific wellness or self-care recommendation
+Please provide a concise and reflective Journal Summary as if the user wrote it themselves, using first-person language ("I", "my"). Use **only** the information in the snippets—do not add any thoughts, feelings, or actions not described.
 
 Format your response exactly as:
 
 Journal Summary:
 <summary here>
-
-Analysis:
-<analysis and recommendations here>
-
-Insights:
-Mood Pattern: <mood pattern analysis>
-Suggestion: <actionable suggestion>
-Achievement: <positive accomplishment>
-Wellness Tip: <wellness recommendation>
 """
         )
         self.summary_chain = LLMChain(llm=self.llm, prompt=self.summary_prompt)
     
-    def process_summary(self, request: SummaryRequest) -> SummaryResponse:
+    def process_summary(self, request: SummaryRequest) -> dict:
         """Process summary request and return structured response"""
         if not request.snippetContents:
             raise HTTPException(status_code=400, detail="snippetContents list cannot be empty.")
@@ -61,51 +42,10 @@ Wellness Tip: <wellness recommendation>
             combined = "\n\n".join(request.snippetContents)
             output = self.summary_chain.run(combined)
 
-            # Initialize default values
-            summary_text = ""
-            analysis_text = ""
-            insights_dict = {
-                "mood": "",
-                "suggestion": "",
-                "achievement": "",
-                "wellness": ""
-            }
+            # Extract summary text
+            summary_text = output.replace("Journal Summary:", "").strip()
 
-            # Split the output into sections
-            sections = output.split("Analysis:")
-            if len(sections) >= 2:
-                # Extract summary
-                summary_text = sections[0].replace("Journal Summary:", "").strip()
-                
-                # Split analysis and insights
-                analysis_sections = sections[1].split("Insights:")
-                analysis_text = analysis_sections[0].strip()
-                
-                # Parse insights if available
-                if len(analysis_sections) >= 2:
-                    insights_text = analysis_sections[1].strip()
-                    
-                    # Parse each insight category
-                    for line in insights_text.split('\n'):
-                        line = line.strip()
-                        if line.startswith("Mood Pattern:"):
-                            insights_dict["mood"] = line.replace("Mood Pattern:", "").strip()
-                        elif line.startswith("Suggestion:"):
-                            insights_dict["suggestion"] = line.replace("Suggestion:", "").strip()
-                        elif line.startswith("Achievement:"):
-                            insights_dict["achievement"] = line.replace("Achievement:", "").strip()
-                        elif line.startswith("Wellness Tip:"):
-                            insights_dict["wellness"] = line.replace("Wellness Tip:", "").strip()
-            else:
-                # Fallback: no proper sections found
-                summary_text = output.strip()
-
-            insights_response = InsightsResponse(**insights_dict)
-            return SummaryResponse(
-                summary=summary_text, 
-                analysis=analysis_text, 
-                insights=insights_response
-            )
+            return {"summary": summary_text}
         except Exception as e:
             traceback.print_exc()
             raise HTTPException(status_code=500, detail=f"Summarization failed: {str(e)}")

--- a/genai/tests/test_api_endpoints.py
+++ b/genai/tests/test_api_endpoints.py
@@ -71,3 +71,54 @@ class TestAPIEndpoints:
         # Test that prefixed routes work
         response = self.client.get("/api/genai/health")
         assert response.status_code == 200
+
+    def test_summary_only_endpoint(self):
+        """Test the summary-only endpoint."""
+        response = self.client.post("/api/genai/summary-only", json=self.sample_request)
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Should only contain summary
+        assert "summary" in data
+        assert isinstance(data["summary"], str)
+        assert len(data["summary"]) > 0
+        
+        # Should not contain analysis or insights
+        assert "analysis" not in data
+        assert "insights" not in data
+
+    def test_insights_only_endpoint(self):
+        """Test the insights-only endpoint."""
+        response = self.client.post("/api/genai/insights-only", json=self.sample_request)
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Should contain analysis and insights
+        assert "analysis" in data
+        assert "insights" in data
+        assert isinstance(data["analysis"], str)
+        assert isinstance(data["insights"], dict)
+        
+        # Insights should have the expected structure
+        insights = data["insights"]
+        assert "moodPattern" in insights
+        assert "suggestion" in insights
+        assert "achievement" in insights
+        assert "wellnessTip" in insights
+        
+        # Should not contain summary
+        assert "summary" not in data
+
+    def test_summary_only_endpoint_validation(self):
+        """Test validation for summary-only endpoint."""
+        empty_request = {"snippetContents": []}
+        response = self.client.post("/api/genai/summary-only", json=empty_request)
+        assert response.status_code == 400
+
+    def test_insights_only_endpoint_validation(self):
+        """Test validation for insights-only endpoint."""
+        empty_request = {"snippetContents": []}
+        response = self.client.post("/api/genai/insights-only", json=empty_request)
+        assert response.status_code == 400

--- a/genai/tests/test_models.py
+++ b/genai/tests/test_models.py
@@ -1,6 +1,6 @@
 import pytest
 from pydantic import ValidationError
-from app.main import SummaryRequest, InsightsResponse, SummaryResponse
+from app.models.schemas import SummaryRequest, InsightsResponse, SummaryResponse
 
 
 class TestPydanticModels:

--- a/genai/tests/test_summary_chain.py
+++ b/genai/tests/test_summary_chain.py
@@ -1,4 +1,4 @@
-from app.main import SummaryResponse, InsightsResponse
+from app.models.schemas import SummaryResponse, InsightsResponse
 
 
 class TestSummaryChain:

--- a/server/api-gateway/src/main/java/com/example/api_gateway/config/GatewayConfig.java
+++ b/server/api-gateway/src/main/java/com/example/api_gateway/config/GatewayConfig.java
@@ -36,7 +36,8 @@ public class GatewayConfig {
 
                                 // Journal Service (with auth filter)
                                 .route("journal-service", r -> r
-                                                .path("/api/journalEntry/**", "/api/snippets/**", "/api/summary/**")
+                                                .path("/api/journalEntry/**", "/api/snippets/**", "/api/summary/**",
+                                                                "/api/insights/**")
                                                 .filters(f -> f.filter(clerkAuthenticationFilter))
                                                 .uri(journalServiceUri))
 
@@ -46,10 +47,10 @@ public class GatewayConfig {
                                                 .filters(f -> f.filter(clerkAuthenticationFilter))
                                                 .uri(genaiServiceUri))
 
-                                 .route("gateway-api-docs", r -> r
-                                                 .path("/api/v3/api-docs/**")
-                                                 .filters(f -> f.redirect(302, "/v3/api-docs"))
-                                                 .uri("no://op"))
+                                .route("gateway-api-docs", r -> r
+                                                .path("/api/v3/api-docs/**")
+                                                .filters(f -> f.redirect(302, "/v3/api-docs"))
+                                                .uri("no://op"))
 
                                 // User Service (api docs)
                                 .route("user-service-docs", r -> r

--- a/server/journal-microservice/src/main/java/com/example/journal_microservice/controller/LLMController.java
+++ b/server/journal-microservice/src/main/java/com/example/journal_microservice/controller/LLMController.java
@@ -4,8 +4,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import com.example.journal_microservice.client.LLMRestClient;
-import com.example.journal_microservice.dto.SnippetContentsResponse;
-import com.example.journal_microservice.dto.InsightsResponse;
 import com.example.journal_microservice.model.JournalEntry;
 import com.example.journal_microservice.model.Snippet;
 import com.example.journal_microservice.model.Insights;
@@ -17,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@RequestMapping("/api/summary")
+@RequestMapping("/api")
 @RestController
 public class LLMController {
 
@@ -28,9 +26,8 @@ public class LLMController {
     @Autowired
     private LLMRestClient llmRestClient;
 
-    @GetMapping("/{journalId}")
-    public ResponseEntity<Map<String, Object>> getSummaryAndInsights(@PathVariable String journalId) {
-
+    @GetMapping("/summary/{journalId}")
+    public ResponseEntity<Map<String, Object>> getSummary(@PathVariable String journalId) {
         Optional<JournalEntry> optionalJournalEntry = journalEntryRepository.findById(journalId);
         if (optionalJournalEntry.isEmpty()) {
             return ResponseEntity.notFound().build();
@@ -44,39 +41,64 @@ public class LLMController {
                 .collect(Collectors.toList());
 
         System.out.println("Snippets content: " + snippetsContent);
-        SnippetContentsResponse llmResult = llmRestClient.generateJournalSummaryAndInsight(snippetsContent);
-        System.out.println("LLM Result: " + llmResult);
+        String summary = llmRestClient.generateJournalSummary(snippetsContent);
+        System.out.println("LLM Summary Result: " + summary);
+        
+        if (summary != null) {
+            journalEntry.setSummary(summary);
+            journalEntryRepository.save(journalEntry);
+        }
+
+        // Prepare summary response
+        Map<String, Object> response = new HashMap<>();
+        response.put("summary", summary != null ? summary : "No summary available");
+        
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/insights/{journalId}")
+    public ResponseEntity<Map<String, Object>> getInsights(@PathVariable String journalId) {
+        Optional<JournalEntry> optionalJournalEntry = journalEntryRepository.findById(journalId);
+        if (optionalJournalEntry.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        JournalEntry journalEntry = optionalJournalEntry.get();
+
+        // Get the snippets associated with the journal entry
+        List<Snippet> snippets = snippetRepository.findByJournalEntryId(journalId);
+        List<String> snippetsContent = snippets.stream()
+                .map(snippet -> snippet.getContent())
+                .collect(Collectors.toList());
+
+        System.out.println("Snippets content: " + snippetsContent);
+        Map<String, Object> llmResult = llmRestClient.generateJournalInsights(snippetsContent);
+        System.out.println("LLM Insights Result: " + llmResult);
+        
         if (llmResult != null) {
-            journalEntry.setSummary(llmResult.summary());
-            
             // Create and populate Insights object
             Insights insights = new Insights();
-            insights.setAnalysis(llmResult.analysis());
+            insights.setAnalysis((String) llmResult.get("analysis"));
             
-            if (llmResult.insights() != null) {
-                insights.setMoodPattern(llmResult.insights().mood());
-                insights.setSuggestion(llmResult.insights().suggestion());
-                insights.setAchievement(llmResult.insights().achievement());
-                insights.setWellnessTip(llmResult.insights().wellness());
+            @SuppressWarnings("unchecked")
+            Map<String, String> insightsData = (Map<String, String>) llmResult.get("insights");
+            if (insightsData != null) {
+                insights.setMoodPattern(insightsData.get("moodPattern"));
+                insights.setSuggestion(insightsData.get("suggestion"));
+                insights.setAchievement(insightsData.get("achievement"));
+                insights.setWellnessTip(insightsData.get("wellnessTip"));
             }
             
             journalEntry.setInsights(insights);
             journalEntryRepository.save(journalEntry);
         }
 
-        // Prepare comprehensive response
+        // Prepare insights response
         Map<String, Object> response = new HashMap<>();
-        response.put("summary", llmResult != null ? llmResult.summary() : "No summary available");
-        response.put("analysis", llmResult != null ? llmResult.analysis() : "No analysis available");
+        response.put("analysis", llmResult != null ? llmResult.get("analysis") : "No analysis available");
         
         // Include insights in the response
-        if (llmResult != null && llmResult.insights() != null) {
-            Map<String, String> insights = new HashMap<>();
-            insights.put("mood", llmResult.insights().mood());
-            insights.put("suggestion", llmResult.insights().suggestion());
-            insights.put("achievement", llmResult.insights().achievement());
-            insights.put("wellness", llmResult.insights().wellness());
-            response.put("insights", insights);
+        if (llmResult != null && llmResult.get("insights") != null) {
+            response.put("insights", llmResult.get("insights"));
         } else {
             response.put("insights", new HashMap<String, String>());
         }


### PR DESCRIPTION
Mainly focused on separating the "summary" endpoint which also provided insights into two: "summary" (which just summarizes the snippets and create a journal entry) and "insights" (which provide insights based on journal entry and snippets)

<img width="1280" height="725" alt="image" src="https://github.com/user-attachments/assets/80431446-b64c-48b2-a0a5-0dc6f0ca9d22" />


Details:
- Implemented `useGenerateSummary` and `useGenerateInsights` hooks for generating journal summaries and insights.
- Updated `useGetInsights` to fetch insights based on journal ID.
- Enhanced `JournalView` to handle new insights and summary generation states.
- Refactored `EditTab` to integrate new hooks and manage loading states for insights and summaries.
- Created `InsightsService` to handle insights generation logic.
- Modified `SummaryService` to focus on summary generation only.
- Updated API endpoints to separate summary and insights functionalities.
- Added tests for new API endpoints and validation checks.